### PR TITLE
Added local quantity input storage

### DIFF
--- a/AlloyDrum.html
+++ b/AlloyDrum.html
@@ -45,8 +45,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/BetaCorruptor.html
+++ b/BetaCorruptor.html
@@ -47,8 +47,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/Hexenon.html
+++ b/Hexenon.html
@@ -46,8 +46,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/NitainExtract.html
+++ b/NitainExtract.html
@@ -47,8 +47,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/PyrusEssence.html
+++ b/PyrusEssence.html
@@ -46,8 +46,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/Sentirum.html
+++ b/Sentirum.html
@@ -46,8 +46,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/dragniwazonmilk.html
+++ b/dragniwazonmilk.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/frumble.html
+++ b/frumble.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/gadoobagorp.html
+++ b/gadoobagorp.html
@@ -16,7 +16,7 @@
       <a class="navbar-brand" href="produce.html">
       <img src="images/logo.png" width="30" height="30">
       <img src="images/back_arrow.png" width="20" height="20">
-      Frumble
+      Gadoobagorp
       </a>
 
     </nav>
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/gorgaricus.html
+++ b/gorgaricus.html
@@ -16,7 +16,7 @@
       <a class="navbar-brand" href="produce.html">
       <img src="images/logo.png" width="30" height="30">
       <img src="images/back_arrow.png" width="20" height="20">
-      Frumble
+      Gorgaricus
       </a>
 
     </nav>
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/kaurian-flour.html
+++ b/kaurian-flour.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/kurporpa.html
+++ b/kurporpa.html
@@ -16,7 +16,7 @@
       <a class="navbar-brand" href="produce.html">
       <img src="images/logo.png" width="30" height="30">
       <img src="images/back_arrow.png" width="20" height="20">
-      Frumble
+      Kurporpa
       </a>
 
     </nav>
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/milkyway.html
+++ b/milkyway.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/molzala-powder.html
+++ b/molzala-powder.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/mooncheese.html
+++ b/mooncheese.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/squelp.html
+++ b/squelp.html
@@ -16,7 +16,7 @@
       <a class="navbar-brand" href="produce.html">
       <img src="images/logo.png" width="30" height="30">
       <img src="images/back_arrow.png" width="20" height="20">
-      Frumble
+      Squelp
       </a>
 
     </nav>
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/steamed-lurqun-noodles.html
+++ b/steamed-lurqun-noodles.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/storeInputLocally.js
+++ b/storeInputLocally.js
@@ -1,0 +1,16 @@
+// replace the value of the quantity element with the saved value
+document.getElementById("quantity").value = getSavedValue("quantity");
+
+// save the element's value to localStorage as (ID, VALUE)
+function saveValue(element) {
+    var id = element.id;
+    var value = element.value;
+    localStorage.setItem(id, value);
+}
+
+function getSavedValue(id) {
+    if (!localStorage.getItem(id)) {
+        return ""; // didn't find anything
+    }
+    return localStorage.getItem(id);
+}

--- a/stratmoscheese.html
+++ b/stratmoscheese.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/tribbles.html
+++ b/tribbles.html
@@ -16,7 +16,7 @@
       <a class="navbar-brand" href="produce.html">
       <img src="images/logo.png" width="30" height="30">
       <img src="images/back_arrow.png" width="20" height="20">
-      Frumble
+      Tribbles
       </a>
 
     </nav>
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/unknowncreatureegg.html
+++ b/unknowncreatureegg.html
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>

--- a/zygote.html
+++ b/zygote.html
@@ -16,7 +16,7 @@
       <a class="navbar-brand" href="dairy_and_eggs.html">
       <img src="images/logo.png" width="30" height="30">
       <img src="images/back_arrow.png" width="20" height="20">
-      Fertilzed zygote
+      Fertilized zygote
       </a>
 
     </nav>
@@ -44,8 +44,11 @@
         Add to cart
       </button>
       Quantity:
-      <input type="number" id="quantity" name="quantity" min="1" max="99">
+      <input type="number" id="quantity" name="quantity" min="1" max="99" onkeyup="saveValue(this)" onchange="saveValue(this)">
     </div>
   </div>
 </div>
+
+<script src="storeInputLocally.js"></script>
+
 </html>


### PR DESCRIPTION
Added script that stores input variables locally to all of the product pages. This ensures that the quantity input value remains on the page even after refreshing or closing and reopening the page. 

The caveat being that this value persists on all product pages. Remains to be seen whether this is worth modifying or not based on the project requirements.